### PR TITLE
give the user a help what to enter into $wgExternalRedirectPages

### DIFF
--- a/ExternalRedirect.i18n.php
+++ b/ExternalRedirect.i18n.php
@@ -24,7 +24,7 @@ $messages['en'] = array(
     'externalredirect-invalidurl' => '== ExternalRedirect Error ==
 Redirection URL is invalid.',
     'externalredirect-denied' => '== ExternalRedirect Error ==
-External redirection is not enabled for this namespace, page or URL.',
+External redirection is not enabled for this namespace, page or URL. This page is: [$1]',
     'externalredirect-denied-url' => 'Intended redirection URL: [$1 $1]',
 );
 

--- a/ExternalRedirect.php
+++ b/ExternalRedirect.php
@@ -67,7 +67,7 @@ function wfExternalRedirectRender($parser, $url = '') {
         }
         return wfMessage('externalredirect-text', $url)->text();
     } else {
-        return wfMessage('externalredirect-denied')->text().($wgExternalRedirectDeniedShowURL 
+        return wfMessage('externalredirect-denied', $parser->getTitle()->getPrefixedText())->text().($wgExternalRedirectDeniedShowURL 
           ? ' '.wfMessage('externalredirect-denied-url', $url)->text() : "");
     }
 }


### PR DESCRIPTION
Hi,

had to do a bit of debugging to find out that you must not substitute spaces in page names by underscores, this explains it